### PR TITLE
Support private mediawiki

### DIFF
--- a/wikiget/__init__.py
+++ b/wikiget/__init__.py
@@ -22,6 +22,6 @@ from .version import __version__
 # set some global constants
 BLOCKSIZE = 65536
 DEFAULT_SITE = 'commons.wikimedia.org'
-DEFAULT_PATH = '/'
+DEFAULT_PATH = '/w/'
 USER_AGENT = 'wikiget/{} (https://github.com/clpo13/wikiget) ' \
              'mwclient/{}'.format(__version__, mwclient_version)

--- a/wikiget/__init__.py
+++ b/wikiget/__init__.py
@@ -22,5 +22,6 @@ from .version import __version__
 # set some global constants
 BLOCKSIZE = 65536
 DEFAULT_SITE = 'commons.wikimedia.org'
+DEFAULT_PATH = '/'
 USER_AGENT = 'wikiget/{} (https://github.com/clpo13/wikiget) ' \
              'mwclient/{}'.format(__version__, mwclient_version)

--- a/wikiget/dl.py
+++ b/wikiget/dl.py
@@ -70,6 +70,8 @@ def download(dl, args):
     try:
         print("Site name: {}".format(site_name))
         site = Site(site_name, path=args.path, clients_useragent=USER_AGENT)
+        if args.username and args.password:
+            site.login(args.username, args.password)
     except ConnectionError:
         # usually this means there is no such site,
         # or there's no network connection

--- a/wikiget/dl.py
+++ b/wikiget/dl.py
@@ -45,10 +45,10 @@ def download(dl, args):
     site_match = valid_site(site_name)
 
     # check for valid site parameter
-    if not site_match:
-        print('Only Wikimedia sites (wikipedia.org and wikimedia.org) '
-              'are currently supported.')
-        sys.exit(1)
+    # if not site_match:
+    #     print('Only Wikimedia sites (wikipedia.org and wikimedia.org) '
+    #           'are currently supported.')
+    #     sys.exit(1)
 
     # check if this is a valid file
     if file_match and file_match.group(1):
@@ -68,7 +68,8 @@ def download(dl, args):
 
     # connect to site and identify ourselves
     try:
-        site = Site(site_name, clients_useragent=USER_AGENT)
+        print("Site name: {}".format(site_name))
+        site = Site(site_name, path=args.path, clients_useragent=USER_AGENT)
     except ConnectionError:
         # usually this means there is no such site,
         # or there's no network connection

--- a/wikiget/wikiget.py
+++ b/wikiget/wikiget.py
@@ -19,7 +19,7 @@ import argparse
 import logging
 import sys
 
-from . import DEFAULT_SITE, __version__
+from . import DEFAULT_SITE, DEFAULT_PATH, __version__
 from .dl import download
 
 
@@ -62,6 +62,9 @@ def main():
                         action='store_true')
     parser.add_argument('-s', '--site', default=DEFAULT_SITE,
                         help='MediaWiki site to download from '
+                        '(default: %(default)s)')
+    parser.add_argument('-p', '--path', default=DEFAULT_PATH,
+                        help='MediaWiki site path to download from '
                         '(default: %(default)s)')
     output_options = parser.add_mutually_exclusive_group()
     output_options.add_argument('-o', '--output',

--- a/wikiget/wikiget.py
+++ b/wikiget/wikiget.py
@@ -66,6 +66,12 @@ def main():
     parser.add_argument('-p', '--path', default=DEFAULT_PATH,
                         help='MediaWiki site path to download from '
                         '(default: %(default)s)')
+    parser.add_argument('--username', default="",
+                        help='MediaWiki site username '
+                        '(default: %(default)s)')
+    parser.add_argument('--password', default="",
+                        help='MediaWiki site password '
+                        '(default: %(default)s)')
     output_options = parser.add_mutually_exclusive_group()
     output_options.add_argument('-o', '--output',
                                 help='write download to OUTPUT')


### PR DESCRIPTION
In order to support a private wiki, I add three options:
* path, the relative path of the wiki
* username, the login user name
* password, the login password